### PR TITLE
Disable coredump bt and storage

### DIFF
--- a/tasks/coredump.yml
+++ b/tasks/coredump.yml
@@ -1,0 +1,46 @@
+---
+- name: Ensure coredump.conf exists
+  ansible.builtin.stat:
+    path: /etc/systemd/coredump.conf
+  register: coredump_conf
+
+- name: Check coredump.conf for [Coredump] section
+  ansible.builtin.lineinfile:
+    path: /etc/systemd/coredump.conf
+    line: "[Coredump]"
+    state: present
+  check_mode: true
+  register: coredump_sec
+  when: coredump_conf.stat.exists
+
+- name: Remove coredump.conf if no [Coredump] section
+  ansible.builtin.file:
+    path: /etc/systemd/coredump.conf
+    state: absent
+  when: (coredump_conf.stat.exists) and (coredump_sec.changed)
+
+- name: Create coredump.conf
+  ansible.builtin.file:
+    path: /etc/systemd/coredump.conf
+    owner: root
+    group: root
+    mode: 0644
+    state: touch
+  when: (not coredump_conf.stat.exists) or (coredump_sec.changed)
+
+- name: Ensure [Coredump] section exists
+  ansible.builtin.lineinfile:
+    path: /etc/systemd/coredump.conf
+    line: "[Coredump]"
+
+- name: Disable coredump backtraces
+  ansible.builtin.lineinfile:
+    path: /etc/systemd/coredump.conf
+    line: "ProcessSizeMax=0"
+    insertafter: "^[Coredump]"
+
+- name: Disable coredump storage
+  ansible.builtin.lineinfile:
+    path: /etc/systemd/coredump.conf
+    line: "Storage=none"
+    insertafter: "^ProcessSizeMax"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,10 @@
   include: system_acc.yml
   tags: system_acc
 
+- name: Coredump config
+  include: coredump.yml
+  tags: coredump
+
 - name: Configure openssh-server
   include: sshd.yml
   tags: sshd


### PR DESCRIPTION
Disable coredump backtraces and storage - remove invalid config file first if needed.